### PR TITLE
MARK: In b2Body::SetTransform, skip FindNewContacts()

### DIFF
--- a/Box2D_v2.2.1/Box2D/Dynamics/b2Body.cpp
+++ b/Box2D_v2.2.1/Box2D/Dynamics/b2Body.cpp
@@ -422,7 +422,10 @@ void b2Body::SetTransform(const b2Vec2& position, float32 angle)
 		f->Synchronize(broadPhase, m_xf, m_xf);
 	}
 
-	m_world->m_contactManager.FindNewContacts();
+	// Skip discovering contacts upon direct SetTransform.  Instead, rely on any new
+	// contacts being discovered during the next physics Step.  This gives better CPU
+	// performance for bulk updating the positions of bodies.
+	// m_world->m_contactManager.FindNewContacts();
 }
 
 void b2Body::SynchronizeFixtures()


### PR DESCRIPTION
To speed up bulk-updates of many bodies.  Any contact events that this
call would have found, instead will be found during the next physical
simulation step.
